### PR TITLE
Update install recommendation to use pyproject.toml

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ installed.
 ## Install
 
 ```
-python setup.py install
+python -m pip install .
 ```
 
 ## Copyright


### PR DESCRIPTION
setup.py appears to have been removed in favor of pyproject.toml, but the readme instructions for install don't reflect that.  This updates the instruction.